### PR TITLE
Add parallax demo

### DIFF
--- a/examples/parallax-demo.html
+++ b/examples/parallax-demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Parallax Demo</title>
+  <link rel="stylesheet" href="parallax.css">
+</head>
+<body>
+  <div class="parallax-container">
+    <div class="parallax-layer layer-back" data-depth="8"></div>
+    <div class="parallax-layer layer-mid" data-depth="4"></div>
+    <div class="parallax-layer layer-front" data-depth="2"></div>
+    <div class="content">
+      <h1>Welcome to AlephSpark</h1>
+      <p>Move your cursor to see the subtle 3D effect.</p>
+    </div>
+  </div>
+  <script src="parallax.js"></script>
+</body>
+</html>

--- a/examples/parallax.css
+++ b/examples/parallax.css
@@ -1,0 +1,39 @@
+.parallax-container {
+  position: relative;
+  overflow: hidden;
+  height: 100vh;
+  perspective: 1000px;
+  background: #111;
+  color: #fff;
+  font-family: Arial, sans-serif;
+}
+.parallax-layer {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  transition: transform 0.3s ease-out;
+  will-change: transform;
+}
+.layer-back {
+  background-image: url('https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=1200&q=60');
+}
+.layer-mid {
+  background-image: url('https://images.unsplash.com/photo-1521493780977-7bc37ec6a150?auto=format&fit=crop&w=1200&q=60');
+  opacity: 0.7;
+}
+.layer-front {
+  background-image: url('https://images.unsplash.com/photo-1526401485004-0d77c1b2cdd0?auto=format&fit=crop&w=1200&q=60');
+  opacity: 0.4;
+}
+.content {
+  position: relative;
+  z-index: 10;
+  text-align: center;
+  top: 45%;
+  transform: translateY(-50%);
+}
+.content h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}

--- a/examples/parallax.js
+++ b/examples/parallax.js
@@ -1,0 +1,27 @@
+(function(){
+  const container = document.querySelector('.parallax-container');
+  if(!container) return;
+  const layers = container.querySelectorAll('.parallax-layer');
+
+  const handleMove = (e) => {
+    const rect = container.getBoundingClientRect();
+    const offsetX = e.clientX - rect.left - rect.width / 2;
+    const offsetY = e.clientY - rect.top - rect.height / 2;
+
+    layers.forEach(layer => {
+      const depth = parseFloat(layer.dataset.depth || '0');
+      const moveX = (offsetX * depth) / rect.width;
+      const moveY = (offsetY * depth) / rect.height;
+      layer.style.transform = `translate3d(${moveX}px, ${moveY}px, 0)`;
+    });
+  };
+
+  const handleLeave = () => {
+    layers.forEach(layer => {
+      layer.style.transform = 'translate3d(0,0,0)';
+    });
+  };
+
+  container.addEventListener('mousemove', handleMove);
+  container.addEventListener('mouseleave', handleLeave);
+})();


### PR DESCRIPTION
## Summary
- add mouse-based parallax effect demo
- simple css and js that move layers with cursor movement
- provide HTML file to see the effect

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c497c7648325ace308101928e4fe